### PR TITLE
Arbitrary code execution fix: Replace exec with execFile

### DIFF
--- a/packages/monorepo-build/src/index.ts
+++ b/packages/monorepo-build/src/index.ts
@@ -22,15 +22,15 @@ export function build(
   } = {}
 ) {
   debug(`cloning ${cloneUrl} into ${directory} ...`)
-  execSync(directory, `git clone ${cloneUrl} .`)
+  execSync(directory, ['git', 'clone', cloneUrl, '.'])
   debug(`(ok)`)
   const pkgs = path.resolve(directory, packagesDirectory)
   debug(`setting commit user ...`)
-  execSync(directory, `git config user.name "${userName}"`)
-  execSync(directory, `git config user.email "${userEmail}"`)
+  execSync(directory, ['git', 'config', 'user.name', userName])
+  execSync(directory, ['git', 'config', 'user.email', userEmail])
   debug(`(ok)`)
   debug(`checking out ${sha} ...`)
-  execSync(directory, `git reset --hard ${sha}`)
+  execSync(directory, ['git', 'reset', '--hard', sha])
   debug(`(ok)`)
 
   debug(`getting packages ...`)
@@ -58,8 +58,8 @@ export function build(
   debug('(ok)')
 
   debug(`committing changes ...`)
-  execSync(directory, 'git add -A')
-  execSync(directory, 'git commit -m "chore: alias packages"')
+  execSync(directory, ['git', 'add', '-A'])
+  execSync(directory, ['git', 'commit', '-m', 'chore: alias packages'])
   debug('(ok)')
 
   return getPackages(pkgs)

--- a/packages/monorepo-build/src/util/exec.ts
+++ b/packages/monorepo-build/src/util/exec.ts
@@ -1,4 +1,4 @@
-import { execSync as _execSync } from 'child_process'
+import { execFileSync as _execSync } from 'child_process'
 
-export const execSync = (cwd: string, command: string) =>
-  _execSync(command, { cwd, env: process.env })
+export const execSync = (cwd: string, command: string[]) =>
+  _execSync(command[0], command.slice(1), { cwd, env: process.env })


### PR DESCRIPTION
### 📊 Metadata *

`Command Injection` in `monorepo-build`

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-monorepo-build/

### ⚙️ Description *

Used child_process.execFile() instead of child_process.exec().

### 💻 Technical Description *

The use of the child_process function exec() is highly discouraged if you accept user input and don't sanitize/escape them. This PR replaces it with execFile() which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:
```

// poc.js
var mb =require("monorepo-build");
mb.build("./","& touch HACKED","SHA-224");
```

2. Execute the following commands in terminal:

```
npm i monorepo-build # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output using ls command before and after the execution.

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106987401-5f338f00-6793-11eb-9038-4be3863f7e84.png)
![image](https://user-images.githubusercontent.com/64132745/106987422-6c507e00-6793-11eb-9dd5-b5daf19a4c2e.png)


After:
![image](https://user-images.githubusercontent.com/64132745/106986778-15967480-6792-11eb-810c-16e88ebe492b.png)

### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1837/files
